### PR TITLE
chore: history.db migration 

### DIFF
--- a/cmd/dryrun/init.go
+++ b/cmd/dryrun/init.go
@@ -98,7 +98,7 @@ func initCmd() *cobra.Command {
 			}
 			defer conn.Close()
 
-			store, err := history.OpenDefault()
+			store, err := openHistoryStore("")
 			if err != nil {
 				return fmt.Errorf("open history store: %w", err)
 			}

--- a/cmd/dryrun/main.go
+++ b/cmd/dryrun/main.go
@@ -575,7 +575,7 @@ func statsCmd() *cobra.Command {
 				return fmt.Errorf("probe: %w", err)
 			}
 
-			store, err := history.OpenDefault()
+			store, err := openHistoryStore("")
 			if err != nil {
 				return fmt.Errorf("open history store: %w", err)
 			}
@@ -744,10 +744,30 @@ func loadSchemaFile(path string) (*schema.SchemaSnapshot, error) {
 }
 
 func openHistoryStore(path string) (*history.Store, error) {
+	var (
+		s   *history.Store
+		err error
+	)
 	if path != "" {
-		return history.Open(path)
+		s, err = history.Open(path)
+	} else {
+		s, err = history.OpenDefault()
 	}
-	return history.OpenDefault()
+	if err == nil {
+		warnIfIncompatible(s)
+	}
+	return s, err
+}
+
+// warn if history.db was written by a different dryrun
+func warnIfIncompatible(s *history.Store) {
+	switch s.Compat() {
+	case history.CompatLegacy:
+		fmt.Fprintln(os.Stderr, "warning: the history database was created by an older dryrun and cannot be read.")
+		fmt.Fprintln(os.Stderr, "         Re-run 'dryrun init', or 'dryrun snapshot pull' to re-import its snapshots.")
+	case history.CompatNewer:
+		fmt.Fprintln(os.Stderr, "warning: the history database was written by a newer dryrun; some data may be unreadable. Please, upgrade dryrun.")
+	}
 }
 
 func resolveSnapshotKey() history.SnapshotKey {

--- a/internal/history/compat_test.go
+++ b/internal/history/compat_test.go
@@ -1,0 +1,160 @@
+package history
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// userVersion reads back the PRAGMA user_version that Open is supposed to
+// stamp. The test reaches into the unexported db handle directly — it lives in
+// package history, and going through a public accessor would only obscure what
+// is being checked.
+func userVersion(t *testing.T, s *Store) int {
+	t.Helper()
+	var v int
+	if err := s.db.QueryRow("PRAGMA user_version").Scan(&v); err != nil {
+		t.Fatalf("read user_version: %v", err)
+	}
+	return v
+}
+
+// tableExists reports whether a table is present — used to prove that opening
+// a foreign store does NOT scribble Go-only tables into it.
+func tableExists(t *testing.T, path, table string) bool {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	defer db.Close()
+	var name string
+	err = db.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, table).Scan(&name)
+	if err == sql.ErrNoRows {
+		return false
+	}
+	if err != nil {
+		t.Fatalf("query sqlite_master: %v", err)
+	}
+	return true
+}
+
+// TestOpenFreshStoreIsCompatOK: a brand-new store must come back CompatOK and
+// must have HistorySchemaVersion stamped into PRAGMA user_version, so the very
+// next open can recognise it as its own without re-inspecting table shapes.
+func TestOpenFreshStoreIsCompatOK(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fresh.db")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close()
+
+	if s.Compat() != CompatOK {
+		t.Errorf("fresh store: got Compat %v, want ok", s.Compat())
+	}
+	if got := userVersion(t, s); got != HistorySchemaVersion {
+		t.Errorf("user_version: got %d, want %d", got, HistorySchemaVersion)
+	}
+}
+
+// TestOpenForeignStoreIsLegacy is the core of the Rust-to-Go detection. We
+// hand-build a SQLite file whose snapshots table looks like the pre-Go (Rust)
+// schema — it carries a `kind` column and, crucially, lacks `db_url_hash`.
+// Open must flag it CompatLegacy AND leave it completely untouched: no
+// migrate, so no empty planner_stats table gets created inside someone's old
+// database. Mutating a foreign store would be the rude, data-risking move.
+func TestOpenForeignStoreIsLegacy(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rust.db")
+
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("create raw db: %v", err)
+	}
+	// Rust-era snapshots table: single table, kind-discriminated, no db_url_hash.
+	_, err = raw.Exec(`CREATE TABLE snapshots (
+		id            INTEGER PRIMARY KEY,
+		kind          TEXT NOT NULL,
+		content_hash  TEXT NOT NULL,
+		snapshot_json TEXT NOT NULL,
+		project_id    TEXT,
+		database_id   TEXT
+	)`)
+	if err != nil {
+		t.Fatalf("seed foreign schema: %v", err)
+	}
+	raw.Close()
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open foreign store should not error: %v", err)
+	}
+	defer s.Close()
+
+	if s.Compat() != CompatLegacy {
+		t.Errorf("foreign store: got Compat %v, want legacy", s.Compat())
+	}
+	// Open must not have run migrate against the foreign file.
+	if tableExists(t, path, "planner_stats") {
+		t.Error("Open created planner_stats inside a foreign store; it must be left untouched")
+	}
+}
+
+// TestOpenNewerStoreIsCompatNewer: a store stamped with a user_version above
+// this build's HistorySchemaVersion was written by a newer dryrun. Open must
+// report CompatNewer rather than silently treating it as its own, since a
+// newer build may have changed the payload format.
+func TestOpenNewerStoreIsCompatNewer(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "newer.db")
+
+	// first open creates a normal Go store...
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	// ...then we forge a version from the future and reopen.
+	if _, err := s.db.Exec("PRAGMA user_version = 999"); err != nil {
+		t.Fatalf("bump user_version: %v", err)
+	}
+	s.Close()
+
+	s2, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer s2.Close()
+	if s2.Compat() != CompatNewer {
+		t.Errorf("future-versioned store: got Compat %v, want newer", s2.Compat())
+	}
+}
+
+// TestOpenAdoptsPreMarkerGoStore: a Go-shaped store from before the
+// user_version marker existed has the right tables but user_version 0. Open
+// must recognise it as its own (db_url_hash present), adopt it by stamping the
+// current version, and report CompatOK — never CompatLegacy.
+func TestOpenAdoptsPreMarkerGoStore(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "premarker.db")
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	// simulate a pre-marker Go store: correct tables, but no version stamp.
+	if _, err := s.db.Exec("PRAGMA user_version = 0"); err != nil {
+		t.Fatalf("clear user_version: %v", err)
+	}
+	s.Close()
+
+	s2, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer s2.Close()
+	if s2.Compat() != CompatOK {
+		t.Errorf("pre-marker Go store: got Compat %v, want ok", s2.Compat())
+	}
+	if got := userVersion(t, s2); got != HistorySchemaVersion {
+		t.Errorf("pre-marker store not re-stamped: user_version %d, want %d", got, HistorySchemaVersion)
+	}
+}

--- a/internal/history/store.go
+++ b/internal/history/store.go
@@ -18,22 +18,49 @@ import (
 	"github.com/boringsql/dryrun/internal/schema"
 )
 
-type Store struct {
-	db *sql.DB
+// database version that goes into PRAGMA
+const HistorySchemaVersion = 1
+
+type (
+	Compat int
+
+	Store struct {
+		db     *sql.DB
+		compat Compat
+	}
+
+	SnapshotSummary struct {
+		ID            int64        `json:"id"`
+		Kind          SnapshotKind `json:"-"`
+		DBURLHash     string       `json:"db_url_hash,omitempty"`
+		Timestamp     time.Time    `json:"timestamp"`
+		ContentHash   string       `json:"content_hash"`
+		Database      string       `json:"database,omitempty"`
+		SchemaRefHash string       `json:"schema_ref_hash,omitempty"`
+		NodeLabel     string       `json:"node_label,omitempty"`
+		ProjectID     *string      `json:"project_id,omitempty"`
+		DatabaseID    *string      `json:"database_id,omitempty"`
+	}
+)
+
+const (
+	CompatOK     Compat = iota // this build's format
+	CompatLegacy               // old rust history.db
+	CompatNewer                // written by a newer dryrun
+)
+
+func (c Compat) String() string {
+	switch c {
+	case CompatLegacy:
+		return "legacy"
+	case CompatNewer:
+		return "newer"
+	default:
+		return "ok"
+	}
 }
 
-type SnapshotSummary struct {
-	ID            int64     `json:"id"`
-	Kind          SnapshotKind `json:"-"`
-	DBURLHash     string    `json:"db_url_hash,omitempty"`
-	Timestamp     time.Time `json:"timestamp"`
-	ContentHash   string    `json:"content_hash"`
-	Database      string    `json:"database,omitempty"`
-	SchemaRefHash string    `json:"schema_ref_hash,omitempty"`
-	NodeLabel     string    `json:"node_label,omitempty"`
-	ProjectID     *string   `json:"project_id,omitempty"`
-	DatabaseID    *string   `json:"database_id,omitempty"`
-}
+func (s *Store) Compat() Compat { return s.compat }
 
 // Opens (or creates) sqlite history db at path
 func Open(path string) (*Store, error) {
@@ -48,13 +75,78 @@ func Open(path string) (*Store, error) {
 	}
 
 	s := &Store{db: db}
+
+	// old rust db, don't migrate it
+	foreign, err := isForeignStore(db)
+	if err != nil {
+		db.Close()
+		return nil, err
+	}
+	if foreign {
+		s.compat = CompatLegacy
+		slog.Debug("history store: incompatible format", "path", path)
+		return s, nil
+	}
+
 	if err := s.migrate(); err != nil {
 		db.Close()
 		return nil, err
 	}
+	s.compat = stampVersion(db)
 
-	slog.Debug("history store opened", "path", path)
+	slog.Debug("history store opened", "path", path, "compat", s.compat)
 	return s, nil
+}
+
+// true if this looks like an old rust history.db, not ours
+func isForeignStore(db *sql.DB) (bool, error) {
+	var name string
+	err := db.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name='snapshots'`).Scan(&name)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("inspect history db: %w", err)
+	}
+
+	rows, err := db.Query(`PRAGMA table_info(snapshots)`)
+	if err != nil {
+		return false, fmt.Errorf("inspect snapshots table: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid     int
+			cname   string
+			ctype   string
+			notnull int
+			dflt    sql.NullString
+			pk      int
+		)
+		if err := rows.Scan(&cid, &cname, &ctype, &notnull, &dflt, &pk); err != nil {
+			return false, err
+		}
+		if cname == "db_url_hash" {
+			return false, nil
+		}
+	}
+	return true, rows.Err()
+}
+
+// save our schema version into the db
+func stampVersion(db *sql.DB) Compat {
+	var v int
+	if err := db.QueryRow("PRAGMA user_version").Scan(&v); err != nil {
+		return CompatOK
+	}
+	if v > HistorySchemaVersion {
+		return CompatNewer
+	}
+	if v != HistorySchemaVersion {
+		_, _ = db.Exec(fmt.Sprintf("PRAGMA user_version = %d", HistorySchemaVersion))
+	}
+	return CompatOK
 }
 
 // Opens .dryrun/history.db in cwd

--- a/internal/mcp/handlers_snapshot.go
+++ b/internal/mcp/handlers_snapshot.go
@@ -68,8 +68,13 @@ func (s *Server) handleReloadSchema(ctx context.Context, _ mcp.CallToolRequest) 
 		s.annotated = &schema.AnnotatedSchema{Schema: snap}
 		s.uninitialized = false
 		s.mu.Unlock()
-		return textResult(fmt.Sprintf("Schema loaded from %s: %d tables, %d views, %d functions",
-			path, len(snap.Tables), len(snap.Views), len(snap.Functions))), nil
+		msg := fmt.Sprintf("Schema loaded from %s: %d tables, %d views, %d functions",
+			path, len(snap.Tables), len(snap.Views), len(snap.Functions))
+		// history.db would carry planner/activity stats but was skipped
+		if note := s.historyNote(); note != nil {
+			msg += "\n\nNote: " + *note + "."
+		}
+		return textResult(msg), nil
 	}
 
 	var lines []string
@@ -115,6 +120,9 @@ func (s *Server) resolveSnapshotForDiff(ctx context.Context, hash, side string) 
 		if hist == nil || key.ProjectID == "" {
 			return nil, fmt.Errorf("no history store available; cannot resolve %s=%s", side, hash)
 		}
+		if note := s.historyNote(); note != nil {
+			return nil, fmt.Errorf("cannot resolve %s=%s: %s", side, hash, *note)
+		}
 		snap, err := hist.GetSchema(ctx, key, history.NewRefHash(hash))
 		if err != nil {
 			return nil, fmt.Errorf("history lookup for %s=%s failed: %v", side, hash, err)
@@ -133,6 +141,9 @@ func (s *Server) resolveSnapshotForDiff(ctx context.Context, hash, side string) 
 	s.mu.RUnlock()
 	if hist == nil || key.ProjectID == "" {
 		return nil, fmt.Errorf("from omitted but no history store available")
+	}
+	if note := s.historyNote(); note != nil {
+		return nil, fmt.Errorf("from omitted: %s", *note)
 	}
 	snap, err := hist.GetSchema(ctx, key, history.NewRefLatest())
 	if err != nil {

--- a/internal/mcp/history_compat_test.go
+++ b/internal/mcp/history_compat_test.go
@@ -1,0 +1,115 @@
+package mcp
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/boringsql/dryrun/internal/history"
+	"github.com/boringsql/dryrun/internal/lint"
+	"github.com/boringsql/dryrun/internal/schema"
+)
+
+// legacyHistoryStore writes a Rust-shaped history.db — a snapshots table with
+// no db_url_hash column — and opens it, yielding a *history.Store that reports
+// CompatLegacy. This is exactly what an MCP user who upgraded from the Rust
+// dryrun would be sitting on: the file is there, but this build cannot read it.
+func legacyHistoryStore(t *testing.T) *history.Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "rust-history.db")
+
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("create raw db: %v", err)
+	}
+	_, err = raw.Exec(`CREATE TABLE snapshots (
+		id            INTEGER PRIMARY KEY,
+		kind          TEXT NOT NULL,
+		content_hash  TEXT NOT NULL,
+		snapshot_json TEXT NOT NULL,
+		project_id    TEXT,
+		database_id   TEXT
+	)`)
+	if err != nil {
+		t.Fatalf("seed rust schema: %v", err)
+	}
+	raw.Close()
+
+	hist, err := history.Open(path)
+	if err != nil {
+		t.Fatalf("history.Open: %v", err)
+	}
+	if hist.Compat() != history.CompatLegacy {
+		t.Fatalf("fixture is not legacy: got Compat %v, want legacy", hist.Compat())
+	}
+	t.Cleanup(func() { hist.Close() })
+	return hist
+}
+
+func minimalSnapshot() *schema.SchemaSnapshot {
+	return &schema.SchemaSnapshot{
+		PgVersion: "PostgreSQL 17.2 on x86_64",
+		Database:  "appdb",
+		Timestamp: time.Now().UTC(),
+	}
+}
+
+// TestInstructionsSurfacesLegacyHistory: an MCP-only user never sees CLI
+// stderr, so a legacy history.db has to reach them through the protocol. The
+// server instructions are delivered to every client on connect, so the
+// compatibility warning must ride along in there. Without this, the user just
+// gets silently degraded results with no clue why.
+func TestInstructionsSurfacesLegacyHistory(t *testing.T) {
+	srv := NewServer(nil, "", minimalSnapshot(), legacyHistoryStore(t), lint.DefaultConfig(), "")
+
+	got := srv.Instructions()
+	if !strings.Contains(got, "older dryrun") {
+		t.Errorf("Instructions() must warn about the legacy history.db, got:\n%s", got)
+	}
+}
+
+// TestInstructionsCleanWhenNoHistory: the warning is conditional. A server
+// with no history store at all (offline mode) must NOT carry a history
+// warning — a false alarm would train users to ignore the real one.
+func TestInstructionsCleanWhenNoHistory(t *testing.T) {
+	srv := NewOfflineServer(minimalSnapshot(), lint.DefaultConfig())
+
+	if got := srv.Instructions(); strings.Contains(got, "older dryrun") {
+		t.Errorf("offline server must not warn about history.db, got:\n%s", got)
+	}
+}
+
+// TestSchemaDiffReportsLegacyHistory: schema_diff resolves snapshot hashes
+// through history.db. When that store is legacy, the failure must explain
+// itself in-band — the tool response is the only channel an MCP user reads.
+// A bare "history lookup failed: no such column" would leave them stranded.
+func TestSchemaDiffReportsLegacyHistory(t *testing.T) {
+	srv := NewServer(nil, "", minimalSnapshot(), legacyHistoryStore(t), lint.DefaultConfig(), "")
+	srv.SetSnapshotKey(history.SnapshotKey{ProjectID: "p", DatabaseID: "d"})
+
+	_, err := srv.resolveSnapshotForDiff(context.Background(), "abc123", "from")
+	if err == nil {
+		t.Fatal("expected an error resolving a snapshot against a legacy store")
+	}
+	if !strings.Contains(err.Error(), "older dryrun") {
+		t.Errorf("error should explain the legacy history.db, got: %v", err)
+	}
+}
+
+// TestHistoryNoteEmptyWhenStoreOK: a healthy, current store produces no note,
+// so neither Instructions nor any tool response nags about it.
+func TestHistoryNoteEmptyWhenStoreOK(t *testing.T) {
+	okStore, err := history.Open(filepath.Join(t.TempDir(), "fresh.db"))
+	if err != nil {
+		t.Fatalf("history.Open: %v", err)
+	}
+	t.Cleanup(func() { okStore.Close() })
+
+	srv := NewServer(nil, "", minimalSnapshot(), okStore, lint.DefaultConfig(), "")
+	if note := srv.historyNote(); note != nil {
+		t.Errorf("a healthy store must yield no note, got %q", *note)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -86,6 +86,26 @@ func (s *Server) loadAnnotatedFromHistory(ctx context.Context) (*schema.Annotate
 	return a, true
 }
 
+// describes a history.db compat problem for the user, or nil if fine
+func (s *Server) historyNote() *string {
+	s.mu.RLock()
+	hist := s.history
+	s.mu.RUnlock()
+	if hist == nil {
+		return nil
+	}
+	var note string
+	switch hist.Compat() {
+	case history.CompatLegacy:
+		note = "the history database is from an older dryrun and cannot be read; re-run `dryrun init` to recapture its snapshots"
+	case history.CompatNewer:
+		note = "the history database was written by a newer dryrun; upgrade dryrun"
+	default:
+		return nil
+	}
+	return &note
+}
+
 func (s *Server) getAnnotated() (*schema.AnnotatedSchema, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -137,7 +157,12 @@ func (s *Server) requirePool() (*pgxpool.Pool, error) {
 }
 
 func (s *Server) Instructions() string {
-	const metaNote = "Each tool response includes _meta.hint (prose) and may include _meta.next: an array of {tool, args} entries that are pre-validated follow-up calls — copy the args verbatim instead of inferring them from the hint."
+	metaNote := "Each tool response includes _meta.hint (prose) and may include _meta.next: an array of {tool, args} entries that are pre-validated follow-up calls — copy the args verbatim instead of inferring them from the hint."
+
+	// surface a history.db compat problem here so MCP-only users see it
+	if note := s.historyNote(); note != nil {
+		metaNote += "\n\nWarning: " + *note + "."
+	}
 
 	snap, err := s.getSchema()
 	if err != nil || snap.PgVersion == "" {


### PR DESCRIPTION
Prepare foundation for history.db upgrades between versions:
- version marker used
- CLI warns the user about the mismatch when it opens an old DB
- MCP propagates the same signal to clients 